### PR TITLE
Various patches from the libkml Debian package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(LIBKML_DATA_DIR  ${CMAKE_SOURCE_DIR}/testdata CACHE "Directory containing te
 #AM_CXXFLAGS = -Wall -Wextra -Wno-unused-parameter -pedantic -fno-rtti
 #AM_TEST_CXXFLAGS = -Wall -Wextra -Wno-unused-parameter -Werror -fno-rtti -DGTEST_HAS_RTTI=0
 if(CMAKE_COMPILER_IS_GNUCXX)
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-Wall -Wextra -Wno-unused-parameter -pedantic -fno-rtti")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-parameter -pedantic -fno-rtti")
 set(TEST_FLAGS "-Wall -Wextra -Wno-unused-parameter -fno-rtti -DGTEST_HAS_RTTI=0")
 endif()
 

--- a/cmake/LibKMLHelper.cmake
+++ b/cmake/LibKMLHelper.cmake
@@ -14,7 +14,7 @@ macro(build_target)
   if(VERSION_STRING)
     set_target_properties(${LIB_NAME} PROPERTIES
       VERSION   "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
-      SOVERSION "${VERSION_MAJOR}.${VERSION_MINOR}")
+      SOVERSION "${VERSION_MAJOR}")
   endif()
   string(LENGTH ${LIB_NAME} ${LIB_NAME}_LEN)
   MATH(EXPR ${LIB_NAME}_END "${${LIB_NAME}_LEN} - 3")

--- a/examples/java/run.sh
+++ b/examples/java/run.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # The relative path to the directory that holds the build shared libraries.
 BUILT_LIB_DIR=../../build/src/swig/.libs
 echo "=== setting shared library path to built libraries dir: $BUILT_LIB_DIR"


### PR DESCRIPTION
In the process of working on [Debian Bug #791132 libkml: library transition may be needed when GCC 5 is the default](https://bugs.debian.org/791132), I've updated the Debian package to use the latest code from this repository.

The switch to CMake allowed for the removal of most patches, only the java run example patch remained. I did run into a small issue with the CMake build when CXXFLAGS are already set in the environment. Both patches are included in this issue.

It's a bit of a shame that the swig bindings cannot be built any more, we have some users of the python bindings in Debian.
