### PR TITLE
Fix include path, from kmlbase/attributes.h to kml/base/attributes.h.

### DIFF
--- a/cmake/LibKMLHelper.cmake
+++ b/cmake/LibKMLHelper.cmake
@@ -21,7 +21,7 @@ macro(build_target)
   string(SUBSTRING ${LIB_NAME} 3 ${${LIB_NAME}_END} ${LIB_NAME}_INCLUDE_DIR)
   install(
     FILES ${LIB_INCS}
-    DESTINATION ${INCLUDE_INSTALL_DIR}/${LIB_NAME})
+    DESTINATION ${INCLUDE_INSTALL_DIR}/${${LIB_NAME}_INCLUDE_DIR})
 
   install_target(${LIB_NAME})
 


### PR DESCRIPTION
This change is required in addition to 361643ce925bd06e16f2311badabf1d05714e75d & 8601371365f7ce5e40215d7a5f3dce22e045ac5c to keep all headers installed under `/usr/include/kml/` as it was with Autotools before.
