### PR TITLE
Install kml/dom/xsd.h required for kml22.h.

### DIFF
--- a/src/kml/dom/CMakeLists.txt
+++ b/src/kml/dom/CMakeLists.txt
@@ -46,6 +46,7 @@ set(INCS
   gx_tour.h
   vec2.h
   xal.h
+  xsd.h
   visitor.h
   visitor_driver.h)
 


### PR DESCRIPTION
As reported in #212, `kml/dom/xsd.h` should be installed because it's required for `kml/dom/kml22.h`.
