### PR TITLE
Fix AsTimeSpan() and AsTimeStamp() to accept gx: elements

### DIFF
--- a/src/kml/dom/kml_cast.cc
+++ b/src/kml/dom/kml_cast.cc
@@ -478,14 +478,14 @@ const StyleMapPtr AsStyleMap(const ElementPtr element) {
 }
 
 const TimeSpanPtr AsTimeSpan(const ElementPtr element) {
-  if (element && element->Type() == Type_TimeSpan) {
+  if (element && element->IsA(Type_TimeSpan)) {
     return boost::static_pointer_cast<TimeSpan>(element);
   }
   return NULL;
 }
 
 const TimeStampPtr AsTimeStamp(const ElementPtr element) {
-  if (element && element->Type() == Type_TimeStamp) {
+  if (element && element->IsA(Type_TimeStamp)) {
     return boost::static_pointer_cast<TimeStamp>(element);
   }
   return NULL;

--- a/tests/kml/dom/kml_cast_test.cc
+++ b/tests/kml/dom/kml_cast_test.cc
@@ -155,7 +155,11 @@ TEST_F(KmlCastTest, TestCasts) {
       factory->CreateElementById(Type_GxSoundCue)) != 0);
   ASSERT_TRUE(AsGxTimeSpan(
       factory->CreateElementById(Type_GxTimeSpan)) != 0);
+  ASSERT_TRUE(AsTimeSpan(
+      factory->CreateElementById(Type_GxTimeSpan)) != 0);
   ASSERT_TRUE(AsGxTimeStamp(
+      factory->CreateElementById(Type_GxTimeStamp)) != 0);
+  ASSERT_TRUE(AsTimeStamp(
       factory->CreateElementById(Type_GxTimeStamp)) != 0);
   ASSERT_TRUE(AsTimePrimitive(
       factory->CreateElementById(Type_GxTimeSpan)) != 0);


### PR DESCRIPTION
Currently AsTimeSpan() and AsTimeStamp() returns NULL on gx:TimeSpan
and gx:TimeStamp whereas those types derive from the non gx: variants,
thus there is no reason for the cast to fail.

This caused a bug in the OGR LIBKML driver:
https://trac.osgeo.org/gdal/ticket/6518
