### PR TITLE
Fixed building on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 else()
   if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DUNICODE /D_UNICODE")
-#    set(BUILD_SHARED_LIBS OFF)
+    set(BUILD_SHARED_LIBS OFF)
   endif()
 endif()
 

--- a/src/kml/base/contrib/strptime.c
+++ b/src/kml/base/contrib/strptime.c
@@ -388,6 +388,12 @@ recurse:
 #endif
 				bp += 3;
 			} else {
+#ifdef WIN32
+#define MAX_TZNAME_BUFFER_SIZE	255
+				char buffer[MAX_TZNAME_BUFFER_SIZE + 1];
+				_get_tzname(0, buffer, MAX_TZNAME_BUFFER_SIZE, 0);
+				char** tzname = &buffer;
+#endif
 				ep = find_string(bp, &i,
 					       	 (const char * const *)tzname,
 					       	  NULL, 2);


### PR DESCRIPTION
Building on Windows suffers from some problems:

1. Of the support libraries, only **Zlib** supports being built as shared libraries. Doing so would require __declspec(dllimport) & __declspec(dllexport) macros. **Minizip** has made some effort, but has several bugs that prevent it from working. **Uriparser** & **Expat** have made no effort in this regard.
2. Similarly, **libkml** has never had support for being built as a shared library. Again, this requires __declspec() scaffolding.
3. strptime.c does not compile on Windows.

Fortunately, the first two can be solved by simply forcing static library generation for Windows. The latter is solved with an #ifdef. I'll admit, I haven't tested the code for strptime.c, mainly because I don't know even know how to trigger that code. But I followed the MSDN documentation so I'm hopeful. At any rate, at least it compiles!
