### PR TITLE
Add "-pthread" argument to fix gtest link errors

### DIFF
--- a/src/kml/engine/CMakeLists.txt
+++ b/src/kml/engine/CMakeLists.txt
@@ -27,6 +27,7 @@ set(INCS
   old_schema_parser_observer.h
   parse_old_schema.h
   schema_parser_observer.h
+  shared_schema_parser_observer.h
   shared_style_parser_observer.h
   style_inliner.h
   style_merger.h

--- a/src/kml/engine/engine_types.h
+++ b/src/kml/engine/engine_types.h
@@ -41,6 +41,10 @@ typedef std::vector<kmldom::ElementPtr> ElementVector;
 // id to a kmldom::StyleSelectorPtr.
 typedef std::map<string, kmldom::StyleSelectorPtr> SharedStyleMap;
 
+// The SharedSchemaParserObserver class uses this data structure to map the XML
+// id to a kmldom::SchemaPtr.
+typedef std::map<std::string, kmldom::SchemaPtr> SharedSchemaMap;
+
 // The ObjectIdParserObserver class uses this data structure to map the XML
 // id to a kmldom::ObjectPtr.
 typedef std::map<string, kmldom::ObjectPtr> ObjectIdMap;

--- a/src/kml/engine/kml_file.cc
+++ b/src/kml/engine/kml_file.cc
@@ -30,7 +30,8 @@
 #include "kml/engine/find_xml_namespaces.h"
 #include "kml/engine/id_mapper.h"
 #include "kml/engine/kmz_file.h"
-#include "kml/dom.h"
+#include "kml/engine/shared_schema_parser_observer.h"
+#include "kml/engine/shared_style_parser_observer.h"
 #include "kml/dom/xml_serializer.h"
 
 using kmlbase::FindXmlNamespaceAndPrefix;
@@ -115,6 +116,9 @@ bool KmlFile::ParseFromString(const string& kml, string* errors) {
   SharedStyleParserObserver shared_style_parser_observer(&shared_style_map_,
                                                          strict_parse_);
   parser.AddObserver(&shared_style_parser_observer);
+  SharedSchemaParserObserver shared_schema_parser_observer(&shared_schema_map_,
+                                                           strict_parse_);
+  parser.AddObserver(&shared_schema_parser_observer);
 
   // Create a ParserObserver to save the parent of all <Link> and <Icon>
   // elements found in the KML file.  See get_link_parents.h for more info.
@@ -220,6 +224,11 @@ kmldom::StyleSelectorPtr KmlFile::GetSharedStyleById(
     const string& id) const {
   SharedStyleMap::const_iterator find = shared_style_map_.find(id);
   return find != shared_style_map_.end() ? find->second : NULL;
+}
+
+kmldom::SchemaPtr KmlFile::GetSharedSchemaById(const std::string& id) const {
+  SharedSchemaMap::const_iterator find = shared_schema_map_.find(id);
+  return find != shared_schema_map_.end() ? find->second : nullptr;
 }
 
 }  // end namespace kmlengine

--- a/src/kml/engine/kml_file.h
+++ b/src/kml/engine/kml_file.h
@@ -129,6 +129,14 @@ class KmlFile : public kmlbase::XmlFile {
     return shared_style_map_;
   }
 
+  // This returns the shared Schema Element with the given id. Returns null if
+  // no Schema with this id exists as a shared schema in the KML file.
+  kmldom::SchemaPtr GetSharedSchemaById(const std::string& id) const;
+
+  const SharedSchemaMap& get_shared_schema_map() const {
+    return shared_schema_map_;
+  }
+
   // This returns the all Elements that may have link children.  See
   // GetLinkParents() for more information.
   const ElementVector& get_link_parent_vector() const {
@@ -174,6 +182,7 @@ class KmlFile : public kmlbase::XmlFile {
   // TODO: use XmlElement's id map.
   ObjectIdMap object_id_map_;
   SharedStyleMap shared_style_map_;
+  SharedSchemaMap shared_schema_map_;
   ElementVector link_parent_vector_;
   KmlCache* kml_cache_;
   bool strict_parse_;

--- a/src/kml/engine/shared_schema_parser_observer.h
+++ b/src/kml/engine/shared_schema_parser_observer.h
@@ -1,0 +1,81 @@
+// Copyright 2022, Google LLC. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  3. Neither the name of Google Inc. nor the names of its contributors may be
+//     used to endorse or promote products derived from this software without
+//     specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+// EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// This file contains the definition of the SharedSchemaParserObserver class.
+
+#ifndef KML_ENGINE_SHARED_SCHEMA_PARSER_OBSERVER_H__
+#define KML_ENGINE_SHARED_SCHEMA_PARSER_OBSERVER_H__
+
+#include <map>
+#include <string>
+
+#include "kml/dom.h"
+#include "kml/dom/parser_observer.h"
+#include "kml/engine/engine_types.h"
+
+namespace kmlengine {
+
+// The SharedSchemaParserObserver is a kmldom::ParserObserver which gathers all
+// all shared Schemas into the supplied SharedSchemaMap.  If strict_parse
+// is true AddChild() returns false on any id collision causing the parse to
+// terminate when this is used with kmldom::Parse::AddObserver().  If
+// strict_parse is false the "last one wins" on any duplicate.
+class SharedSchemaParserObserver : public kmldom::ParserObserver {
+ public:
+  // A SharedSchemaMap must be supplied.
+  SharedSchemaParserObserver(SharedSchemaMap* const shared_schema_map,
+                             const bool strict_parse)
+      : shared_schema_map_(shared_schema_map), strict_parse_(strict_parse) {}
+
+  virtual ~SharedSchemaParserObserver() {}
+
+  // ParserObserver::AddChild()
+  virtual bool AddChild(const kmldom::ElementPtr& parent,
+                        const kmldom::ElementPtr& child) {
+    // A shared Schema is one with an id that is a child of a Document. If this
+    // id already has a mapping return false to terminate the parse.
+    if (kmldom::DocumentPtr document = kmldom::AsDocument(parent)) {
+      if (kmldom::SchemaPtr sp = kmldom::AsSchema(child)) {
+        if (sp->has_id()) {
+          if (strict_parse_ && shared_schema_map_->find(sp->get_id()) !=
+                                   shared_schema_map_->end()) {
+            return false;  // Duplicate id, fail parse.
+          }
+        }
+        // No such mapping so save it, and "last one wins" on non-strict parse.
+        (*shared_schema_map_)[sp->get_id()] = sp;
+      }
+    }
+    return true;  // Not a duplicate id, keep parsing.
+  }
+
+ private:
+  SharedSchemaMap* shared_schema_map_;
+  bool strict_parse_;
+};
+
+}  // end namespace kmlengine
+
+#endif  // KML_ENGINE_SHARED_SCHEMA_PARSER_OBSERVER_H__

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,10 @@ include_directories(${GTEST_INCLUDE_DIR})
 include_directories(${CMAKE_SOURCE_DIR}/tests)
 add_definitions("-DDATADIR=\"${LIBKML_DATA_DIR}\"")
 
+if(NOT MSVC)
+  add_link_options(-pthread)
+endif()
+
 add_subdirectory(kml)
 if(WITH_SWIG)
   add_subdirectory(swig)

--- a/tests/kml/engine/CMakeLists.txt
+++ b/tests/kml/engine/CMakeLists.txt
@@ -23,6 +23,7 @@ object_id_parser_observer
 old_schema_parser_observer
 parse_old_schema
 schema_parser_observer
+shared_schema_parser_observer
 shared_style_parser_observer
 style_inliner
 style_merger

--- a/tests/kml/engine/kml_file_test.cc
+++ b/tests/kml/engine/kml_file_test.cc
@@ -49,6 +49,7 @@ using kmldom::KmlFactory;
 using kmldom::KmlPtr;
 using kmldom::ObjectPtr;
 using kmldom::PlacemarkPtr;
+using kmldom::SchemaPtr;
 using kmldom::StyleMapPtr;
 using kmldom::StyleSelectorPtr;
 
@@ -188,6 +189,35 @@ TEST_F(KmlFileTest, TestBasicGetSharedStyleById) {
   ASSERT_EQ(kFolderStyleId, object->get_id());
   // ...but is not found as a shared style.
   ASSERT_FALSE(kml_file_->GetSharedStyleById(kFolderStyleId));
+}
+
+// Verify NULL is returned for a non-existent shared style.
+TEST_F(KmlFileTest, TestNullGetSharedSchemaById) {
+  kml_file_ = KmlFile::CreateFromParse("<kml/>", nullptr);
+  ASSERT_FALSE(kml_file_->GetSharedSchemaById("nonesuch-schema"));
+}
+
+// Verify a basic shared schema is found.
+TEST_F(KmlFileTest, TestBasicGetSharedSchemaById) {
+  // Use ParseFromString to insert shared styles into the shared style map.
+  const std::string kSchemaId1("my_awesome_schema");
+  const std::string kSchemaId2("another_schema");
+  kml_file_ = KmlFile::CreateFromParse(
+    "<Document>"
+      "<Schema id=\"" + kSchemaId1 + "\"/>"
+      "<Schema id=\"" + kSchemaId2 + "\"/>"
+    "</Document>", NULL);
+  ASSERT_TRUE(kml_file_);  // Verify the parse succeeded.
+
+  // Verify both schemas were found.
+  SchemaPtr schema1 = kml_file_->GetSharedSchemaById(kSchemaId1);
+  ASSERT_NE(schema1, nullptr);
+  ASSERT_TRUE(AsSchema(schema1));  // Verify it's a <Schema>
+  ASSERT_EQ(kSchemaId1, schema1->get_id());
+  SchemaPtr schema2 = kml_file_->GetSharedSchemaById(kSchemaId2);
+  ASSERT_NE(schema2, nullptr);
+  ASSERT_TRUE(AsSchema(schema2));  // Verify it's a <Schema>
+  ASSERT_EQ(kSchemaId2, schema2->get_id());
 }
 
 // This is an internal helper function to verify that the passed element

--- a/tests/kml/engine/old_schema_parser_observer_test.cc
+++ b/tests/kml/engine/old_schema_parser_observer_test.cc
@@ -97,6 +97,10 @@ TEST_F(OldSchemaParserObserverTest, TestDestructor) {
   ASSERT_EQ(kSchema0Name_, schema_name_map_[kSchema0Name_]->get_name());
   ASSERT_EQ(kSchema1Name_, schema_name_map_[kSchema1Name_]->get_name());
 }
-#endif
+#else  // #if 0
+// We need to have at least one test present for things to link correctly.
+TEST_F(OldSchemaParserObserverTest, Placeholder) {
+}
+#endif  // !#if 0
 
 }  // end namespace kmlengine

--- a/tests/kml/engine/shared_schema_parser_observer_test.cc
+++ b/tests/kml/engine/shared_schema_parser_observer_test.cc
@@ -1,0 +1,132 @@
+// Copyright 2022, Google LLC. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//  3. Neither the name of Google Inc. nor the names of its contributors may be
+//     used to endorse or promote products derived from this software without
+//     specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+// EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+// OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+// ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// This file contains the unit tests for the SharedSchemaParserObserver class.
+
+#include "kml/engine/shared_schema_parser_observer.h"
+#include "boost/scoped_ptr.hpp"
+#include "kml/dom/kml_factory.h"
+#include "gtest/gtest.h"
+
+namespace kmlengine {
+
+class SharedSchemaParserObserverTest : public testing::Test {
+ protected:
+  virtual void SetUp() {
+    // Make some elements used in most tests.
+    kmldom::KmlFactory* factory = kmldom::KmlFactory::GetFactory();
+    document_ = factory->CreateDocument();
+    folder_ = factory->CreateFolder();
+    kSchema0Id_ = "schema0";
+    schema0_ = factory->CreateSchema();
+    schema0_->set_id(kSchema0Id_);
+    kSchema1Id_ = "schema1";
+    schema1_ = factory->CreateSchema();
+    schema1_->set_id(kSchema1Id_);
+    schema_no_id_ = factory->CreateSchema();
+    // Create a non-strict SharedSchemaParserObserver.
+    shared_schema_parser_observer_.reset(
+        new SharedSchemaParserObserver(&shared_schema_map_, false));
+  }
+
+  kmldom::DocumentPtr document_;
+  kmldom::FolderPtr folder_;
+  std::string kSchema0Id_;
+  kmldom::SchemaPtr schema0_;
+  std::string kSchema1Id_;
+  kmldom::SchemaPtr schema1_;
+  kmldom::SchemaPtr schema_no_id_;
+  SharedSchemaMap shared_schema_map_;
+  boost::scoped_ptr<SharedSchemaParserObserver> shared_schema_parser_observer_;
+};
+
+// Verify that AddChild() accepts shared Schemas.
+TEST_F(SharedSchemaParserObserverTest, TestAddChildSharedSchema) {
+  // Verify that AddChild() does not detect a dupe.
+  ASSERT_TRUE(shared_schema_parser_observer_->AddChild(document_, schema0_));
+  // Verify that there is only one entry in the map.
+  ASSERT_EQ(static_cast<size_t>(1), shared_schema_map_.size());
+
+  // Verify that the id maps to the Style.
+  kmldom::SchemaPtr object = shared_schema_map_[kSchema0Id_];
+  ASSERT_EQ(kSchema0Id_, object->get_id());
+  ASSERT_EQ(kmldom::Type_Schema, object->Type());
+
+  // Verify that AddChild() does not detect a dupe.
+  ASSERT_TRUE(shared_schema_parser_observer_->AddChild(document_, schema1_));
+  // Verify that there are now 2 entries in the map.
+  ASSERT_EQ(static_cast<size_t>(2), shared_schema_map_.size());
+  // Verify that the id maps to Schema #1
+  object = shared_schema_map_[kSchema1Id_];
+  ASSERT_EQ(kSchema1Id_, object->get_id());
+  ASSERT_EQ(kmldom::Type_Schema, object->Type());
+}
+
+// Verify that NewElement() exists and alwyas returns true.
+TEST_F(SharedSchemaParserObserverTest, TestNewElement) {
+  // Verify that NewElement() accepts StyleSelectors.
+  ASSERT_TRUE(shared_schema_parser_observer_->NewElement(schema0_));
+  // Verify that a 2nd call succeeds given that NewElement is a nop
+  ASSERT_TRUE(shared_schema_parser_observer_->NewElement(schema0_));
+  ASSERT_TRUE(shared_schema_parser_observer_->NewElement(schema1_));
+  // Style with no id accepted fine:
+  ASSERT_TRUE(shared_schema_parser_observer_->NewElement(schema_no_id_));
+  // Document, Folder both fine...
+  ASSERT_TRUE(shared_schema_parser_observer_->NewElement(folder_));
+  ASSERT_TRUE(shared_schema_parser_observer_->NewElement(document_));
+}
+
+// Verify that AddChild() properly detects a duplicate Object id when
+// strict_parse is true.
+TEST_F(SharedSchemaParserObserverTest, TestAddChildDetectsDupeId) {
+  boost::scoped_ptr<SharedSchemaParserObserver> shared_style_parser_observer(
+      new SharedSchemaParserObserver(&shared_schema_map_, true));
+  // Pass a parent-child that will be added to the map.
+  ASSERT_TRUE(shared_style_parser_observer->AddChild(document_, schema0_));
+  // Verify that AddChild() detected the dupe.
+  ASSERT_FALSE(shared_style_parser_observer->AddChild(document_, schema0_));
+  // Verify that the map was not affected.
+  ASSERT_EQ(static_cast<size_t>(1), shared_schema_map_.size());
+  kmldom::ObjectPtr object = shared_schema_map_[kSchema0Id_];
+  ASSERT_EQ(kSchema0Id_, object->get_id());
+  ASSERT_EQ(kmldom::Type_Schema, object->Type());
+}
+
+// Verify that the destructor does not affect the map.
+TEST_F(SharedSchemaParserObserverTest, TestDestructor) {
+  // Use AddChild() to put some entries in the map.
+  ASSERT_TRUE(shared_schema_parser_observer_->AddChild(document_, schema0_));
+  ASSERT_TRUE(shared_schema_parser_observer_->AddChild(document_, schema1_));
+
+  // Verify that deleting the observer does not affect the map.
+  shared_schema_parser_observer_.reset();
+
+  // Verify that the object map has exactly the 2 expected mappings.
+  ASSERT_EQ(static_cast<size_t>(2), shared_schema_map_.size());
+  ASSERT_EQ(kSchema0Id_, shared_schema_map_[kSchema0Id_]->get_id());
+  ASSERT_EQ(kSchema1Id_, shared_schema_map_[kSchema1Id_]->get_id());
+}
+
+}  // end namespace kmlengine


### PR DESCRIPTION
Building tests with the current version of gtest (a.k.a. googletest) results in pthread-related link errors, most easily resolved by adding the "-pthread" linker argument.