### PR TITLE
Add placeholder test in OldSchemaParserObserverTest

### DIFF
--- a/tests/kml/engine/old_schema_parser_observer_test.cc
+++ b/tests/kml/engine/old_schema_parser_observer_test.cc
@@ -97,6 +97,10 @@ TEST_F(OldSchemaParserObserverTest, TestDestructor) {
   ASSERT_EQ(kSchema0Name_, schema_name_map_[kSchema0Name_]->get_name());
   ASSERT_EQ(kSchema1Name_, schema_name_map_[kSchema1Name_]->get_name());
 }
-#endif
+#else  // #if 0
+// We need to have at least one test present for things to link correctly.
+TEST_F(OldSchemaParserObserverTest, Placeholder) {
+}
+#endif  // !#if 0
 
 }  // end namespace kmlengine


### PR DESCRIPTION
At least one test must be present to prevent a link error, otherwise we're basically trying to build a program with no body. Alternative would be to comment out the test from CMakeLists.txt.