### PR TITLE
Remove unnecessary std::unary_function for C++17 support

### DIFF
--- a/src/kml/xsd/xsd_file.cc
+++ b/src/kml/xsd/xsd_file.cc
@@ -50,7 +50,7 @@ XsdFile* XsdFile::CreateFromParse(const string& xsd_data,
 
 // TODO: mem_fun might help avoid this functor
 typedef std::pair<string, XsdElementPtr> NameElementPair;
-struct GetElement : public std::unary_function<NameElementPair, void> {
+struct GetElement {
   GetElement(XsdElementVector* elements)
     : elements_(elements) {
   }


### PR DESCRIPTION
`std::unary_function` has been removed in C++17. The functor works just find without the subclassing.