### PR TITLE
Fix out-of-bounds in set_color_abgr

### DIFF
--- a/src/kml/base/color32.h
+++ b/src/kml/base/color32.h
@@ -137,7 +137,7 @@ class Color32 {
     if (color_abgr.size() > 0 && color_abgr[offset] == '#') {
       offset ++;
     }
-    size_t length = color_abgr.size() >= 8 + offset ? 8 : color_abgr.size();
+    size_t length = color_abgr.size() >= 8 + offset ? 8 : color_abgr.size() - offset;
     for(size_t i = offset; i < length + offset; ++i) {
       out = out * 16;
       if (color_abgr[i] >= '0' && color_abgr[i] <= '9') {


### PR DESCRIPTION
The loop would access `color_abgr` out-of-bounds in rare cases, e.g. if `offset` was not 0 and the remaining length was less than 8. For instance, the input `"  0123"` leads to this. The change bounds the number of iteration to ensure it stays within bounds.